### PR TITLE
Refactor/new version calculator

### DIFF
--- a/lib/bundler/patch.rb
+++ b/lib/bundler/patch.rb
@@ -5,6 +5,7 @@ module Bundler
   end
 end
 
+require 'bundler/patch/new_version_calculator'
 require 'bundler/patch/updater'
 require 'bundler/patch/gemfile'
 require 'bundler/patch/ruby_version'

--- a/lib/bundler/patch/new_version_calculator.rb
+++ b/lib/bundler/patch/new_version_calculator.rb
@@ -7,14 +7,20 @@ class NewVersionCalculator
   def run
     return old_version if patched_versions.include?(old_version)
 
-    patched_versions << old_version
-    patched_versions.sort!
-    patched_versions.delete_if { |v| v.split(/\./).first != old_version.split(/\./).first }
-
-    patched_versions[patched_versions.index(old_version) + 1]
+    candidates[candidates.index(old_version) + 1]
   end
 
   private
 
     attr_reader :old_version, :patched_versions
+
+    def candidates
+      [
+        patched_versions, old_version
+      ].flatten(1).select { |version| first_part(version) == first_part(old_version) }.sort
+    end
+
+    def first_part(version)
+      version.split(/\./).first
+    end
 end

--- a/lib/bundler/patch/new_version_calculator.rb
+++ b/lib/bundler/patch/new_version_calculator.rb
@@ -1,0 +1,20 @@
+class NewVersionCalculator
+  def initialize(old_version, patched_versions)
+    @old_version = old_version
+    @patched_versions = patched_versions
+  end
+
+  def run
+    return old_version if patched_versions.include?(old_version)
+
+    patched_versions << old_version
+    patched_versions.sort!
+    patched_versions.delete_if { |v| v.split(/\./).first != old_version.split(/\./).first }
+
+    patched_versions[patched_versions.index(old_version) + 1]
+  end
+
+  private
+
+    attr_reader :old_version, :patched_versions
+end

--- a/lib/bundler/patch/updater.rb
+++ b/lib/bundler/patch/updater.rb
@@ -17,7 +17,7 @@ module Bundler::Patch
     end
 
     def calc_new_version(old_version)
-      NewVersionCalculator.new(old_version, @patched_versions.dup).run
+      NewVersionCalculator.new(old_version, @patched_versions).run
     end
 
     def file_replace

--- a/lib/bundler/patch/updater.rb
+++ b/lib/bundler/patch/updater.rb
@@ -17,14 +17,7 @@ module Bundler::Patch
     end
 
     def calc_new_version(old_version)
-      old = old_version
-      all = @patched_versions.dup
-      return old_version if all.include?(old)
-
-      all << old
-      all.sort!
-      all.delete_if { |v| v.split(/\./).first != old.split(/\./).first } # strip non-matching major revs
-      all[all.index(old) + 1]
+      NewVersionCalculator.new(old_version, @patched_versions.dup).run
     end
 
     def file_replace

--- a/spec/bundler/unit/new_version_calculator_spec.rb
+++ b/spec/bundler/unit/new_version_calculator_spec.rb
@@ -1,0 +1,79 @@
+require_relative '../../spec_helper'
+
+describe NewVersionCalculator do
+  describe '#run' do
+    let(:candidates) { %w(1.9.3-p550 2.1.4 ruby-2.1.4-p265 jruby-1.7.16.1) }
+
+    def expect(old_version:, patched_versions: candidates)
+      NewVersionCalculator.new(old_version, patched_versions).run
+    end
+
+    context 'ruby version' do
+      it 'upgrades from 1.7 to 1.9.3-p550' do
+        expect(old_version: '1.7').should eq '1.9.3-p550'
+      end
+
+      it 'upgrades from 1.8 to 1.9.3-p550' do
+        expect(old_version: '1.8').should eq '1.9.3-p550'
+      end
+
+      it 'upgrades from 1.9 to 1.9.3-p550' do
+        expect(old_version: '1.9').should eq '1.9.3-p550'
+      end
+
+      it 'upgrades 1.9.3-p484 to 1.9.3-p550' do
+        expect(old_version: '1.9.3-p484').should eq '1.9.3-p550'
+      end
+
+      it 'upgrades from 2 to 2.1.4' do
+        expect(old_version: '2').should eq '2.1.4'
+      end
+
+      it 'upgrades from 2.0.0-p95 to 2.1.4' do
+        expect(old_version: '2.0.0-p95').should eq '2.1.4'
+      end
+
+      it 'upgrades 2.1.2 to 2.1.4' do
+        expect(old_version: '2.1.2').should eq '2.1.4'
+      end
+
+      it 'upgrades from 2.1.2-p95 to 2.1.4' do
+        expect(old_version: '2.1.2-p95').should eq '2.1.4'
+      end
+
+      it 'upgrades from ruby-2.1.2 to ruby-2.1.4-p265' do
+        expect(old_version: 'ruby-2.1.2').should eq 'ruby-2.1.4-p265'
+      end
+
+      it 'upgrades from ruby-2.1.2-p0 to ruby-2.1.4-p265' do
+        expect(old_version: 'ruby-2.1.2-p0').should eq 'ruby-2.1.4-p265'
+      end
+
+      it 'upgrades from ruby-2.1.2-p95 to ruby-2.1.4-p265' do
+        expect(old_version: 'ruby-2.1.2-p95').should eq 'ruby-2.1.4-p265'
+      end
+
+      it 'upgrades from jruby-1.6.5 to jruby-1.7.16.1' do
+        expect(old_version: 'jruby-1.6.5').should eq 'jruby-1.7.16.1'
+      end
+
+      it 'upgrades from jruby-1.7 to jruby-1.7.16.1' do
+        expect(old_version: 'jruby-1.7').should eq 'jruby-1.7.16.1'
+      end
+
+      it 'upgrades jruby-1.7.16 to jruby-1.7.16.1' do
+        expect(old_version: 'jruby-1.7.16').should eq 'jruby-1.7.16.1'
+      end
+    end
+
+    context 'gem version' do
+      it 'do not upgrade to major version' do
+        expect(old_version: '2.4', patched_versions: %w(3.1.1)).should eq nil
+      end
+
+      it 'upgrade from rails 3.2.2 to 3.2.22.2' do
+        expect(old_version: '3.2.2', patched_versions: %w(3.2.22.2)).should eq '3.2.22.2'
+      end
+    end
+  end
+end

--- a/spec/bundler/unit/updater_spec.rb
+++ b/spec/bundler/unit/updater_spec.rb
@@ -3,38 +3,5 @@ require_relative '../../spec_helper'
 require 'fileutils'
 
 describe UpdateSpec do
-  describe 'calc_new_version' do
-    describe 'ruby versions' do
-      before do
-        patched_versions = %w(1.9.3-p550 2.1.4 ruby-2.1.4-p265 jruby-1.7.16.1)
-        @u = UpdateSpec.new(patched_versions: patched_versions)
-      end
-
-      it 'ruby versions' do
-        @u.calc_new_version('1.8').should == '1.9.3-p550'
-        @u.calc_new_version('1.9').should == '1.9.3-p550'
-        @u.calc_new_version('1.9.3-p484').should == '1.9.3-p550'
-        @u.calc_new_version('2.0.0-p95').should == '2.1.4'
-        @u.calc_new_version('2').should == '2.1.4'
-        @u.calc_new_version('2.1.2').should == '2.1.4'
-        @u.calc_new_version('2.1.2-p95').should == '2.1.4'
-        @u.calc_new_version('jruby-1.7').should == 'jruby-1.7.16.1'
-        @u.calc_new_version('jruby-1.6.5').should == 'jruby-1.7.16.1'
-        @u.calc_new_version('1.7').should == '1.9.3-p550'
-        @u.calc_new_version('ruby-2.1.2-p95').should == 'ruby-2.1.4-p265'
-        @u.calc_new_version('ruby-2.1.2-p0').should == 'ruby-2.1.4-p265'
-        @u.calc_new_version('ruby-2.1.2').should == 'ruby-2.1.4-p265'
-      end
-    end
-
-    describe 'gem versions' do
-      it 'should stay put on major version upgrade' do
-        # major version should mean breaking changes, so don't do it.
-        @u = UpdateSpec.new(patched_versions: %w(3.1.1))
-        @u.calc_new_version('2.4').should == nil
-      end
-    end
-  end
-
   it 'should not dump output on test run'
 end


### PR DESCRIPTION
Hi Chris, 

I am getting started with the codebase, and I find it extract to smaller class can be easier to understand and easier to write tests (in my opinion). But the downsides are the cost of file jumps (for reader) and a new dependency for `UpdateSpec` (now depends on `NewVersionCalculator`).

2bbc58d is on your call, I change it so there is no need to call `.dup` when passing in `patched_versions`, so the reader won't have to worry: Oh! Something destructive goes on there.

What do you think? :)