### PR TITLE
Support gems.rb for RubyVersion

### DIFF
--- a/lib/bundler/patch/ruby_version.rb
+++ b/lib/bundler/patch/ruby_version.rb
@@ -1,9 +1,12 @@
 module Bundler::Patch
   class RubyVersion < UpdateSpec
+    RUBY_VERSION_LINE_REGEXPS = [/ruby\s+["'](.*)['"]/]
+
     def self.files
       {
         '.ruby-version' => [/.*/],
-        'Gemfile' => [/ruby\s+["'](.*)['"]/]
+        'Gemfile' => RUBY_VERSION_LINE_REGEXPS,
+        'gems.rb' => RUBY_VERSION_LINE_REGEXPS,
       }
     end
 

--- a/spec/bundler/unit/ruby_version_spec.rb
+++ b/spec/bundler/unit/ruby_version_spec.rb
@@ -25,7 +25,7 @@ describe RubyVersion do
       File.open(fn, 'w') { |f| f.puts old[i] }
 
       File.open(File.join(dir, 'Gemfile'), 'w') { |f| f.puts "ruby '#{old[i]}'"}
-      # FileUtils.cp File.expand_path('../../../fixture/.jenkins.xml', __FILE__), dir
+      File.open(File.join(dir, 'gems.rb'), 'w') { |f| f.puts "ruby '#{old[i]}'"}
     end
   end
 
@@ -43,6 +43,14 @@ describe RubyVersion do
     read_spec_contents(@specs[0], 'Gemfile').should == "ruby '1.9.3-p550'"
     read_spec_contents(@specs[1], 'Gemfile').should == "ruby '2.1.4'"
     read_spec_contents(@specs[2], 'Gemfile').should == "ruby 'jruby-1.7.16.1'"
+  end
+
+  it 'should update gems.rb' do
+    @specs.map(&:update)
+
+    read_spec_contents(@specs[0], 'gems.rb').should == "ruby '1.9.3-p550'"
+    read_spec_contents(@specs[1], 'gems.rb').should == "ruby '2.1.4'"
+    read_spec_contents(@specs[2], 'gems.rb').should == "ruby 'jruby-1.7.16.1'"
   end
 
   def read_spec_contents(spec, filename)


### PR DESCRIPTION
This pull request adds the ability to update ruby version line in `gems.rb` file.

[gems.rb supported since Bundler v.1.8.0.pre](https://github.com/bundler/bundler/blob/2-0-dev/CHANGELOG.md#180pre-2015-01-26) (introduced at bundler/bundler@0823e10).