### PR TITLE
Ensure cache is updated after install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ matrix:
     - rvm: 2.3.1
       env: BUNDLER_TEST_VERSION=1.12.5
     - rvm: 2.3.1
-      env: BUNDLER_TEST_VERSION=1.13.3
+      env: BUNDLER_TEST_VERSION=1.13.5

--- a/lib/bundler/patch/cli.rb
+++ b/lib/bundler/patch/cli.rb
@@ -118,6 +118,7 @@ module Bundler::Patch
       # may end up concluding everything can be resolved locally, nothing is changing,
       # and then nothing is done. lib/bundler/cli/update.rb also hard-codes this.
       Bundler::Installer.install(Bundler.root, prep.bundler_def, {'update' => true})
+      Bundler.load.cache if Bundler.app_cache.exist?
     end
   end
 end

--- a/lib/bundler/patch/version.rb
+++ b/lib/bundler/patch/version.rb
@@ -1,5 +1,5 @@
 module Bundler
   module Patch
-    VERSION = '0.10.1'
+    VERSION = '0.10.2'
   end
 end


### PR DESCRIPTION
Fixes #36. In cases where vendor/cache exists, we need to make sure it
gets updated.

The underlying problem here is Bundler doesn't have a reusable "and now
install the gems and do all the other stuff that should be done" bit -
it's duped throughout the CLI classes. Maybe that'll happen in the
future.